### PR TITLE
LIBITD-1884. Initial implementation of search functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :test do
   gem 'simplecov', '= 0.21.2', require: false
   gem 'simplecov-rcov', '= 0.2.3', require: false
   gem 'faker', '>= 2.17.0'
+  gem 'rails-controller-testing', '>= 1.0.5'
 end
 
 gem 'tzinfo-data', '>= 1.2016.7' # Don't rely on OSX/Linux timezone data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,10 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.3)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -284,6 +288,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3)
+  rails-controller-testing (>= 1.0.5)
   ransack (>= 2.4.2)
   rubocop (= 1.11.0)
   rubocop-checkstyle_formatter

--- a/app/controllers/handles_controller.rb
+++ b/app/controllers/handles_controller.rb
@@ -8,6 +8,26 @@ class HandlesController < ApplicationController
     @q = Handle.ransack(params[:q])
     @q.sorts = 'updated_at desc' if @q.sorts.empty?
     @handles = @q.result.page(params[:page])
+
+    @expand_sort_form = search_params?
+    @show_no_handles_found = @handles.count.zero?
+  end
+
+  # Returns true if the request contains non-empty search parameters,
+  # false otherwise.
+  #
+  # Mainly intended for determining whether the search panel should be shown
+  # as expanded or collapsed
+  def search_params?
+    q = params[:q]
+    return false if q.nil?
+
+    q.each do |key, value|
+      # Skip sort key
+      next if key == 's'
+      return true if value.present?
+    end
+    false
   end
 
   # GET /handles/1 or /handles/1.json

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,5 +2,6 @@
 
 class HomeController < ApplicationController
   def index
+    @q = Handle.ransack(params[:q])
   end
 end

--- a/app/models/handle.rb
+++ b/app/models/handle.rb
@@ -9,6 +9,16 @@ class Handle < ApplicationRecord
   validates :repo_id, presence: true
   validate :validate_url
 
+  # Ransack object to allow "handle" (i.e., "<prefix>/<suffix>") searches
+  ransacker :handle do |parent|
+    Arel::Nodes::InfixOperation.new(
+      '||', Arel::Nodes::InfixOperation.new(
+              '||', parent.table[:prefix], Arel::Nodes.build_quoted('/')
+            ),
+      parent.table[:suffix]
+    )
+  end
+
   # Lock for ensuring synchronization in mint_next_suffix
   @@semaphore = Mutex.new # rubocop:disable Style/ClassVars
 

--- a/app/views/handles/_no_handles_found.html.erb
+++ b/app/views/handles/_no_handles_found.html.erb
@@ -1,0 +1,5 @@
+<div class="alert alert-warning" role="alert">
+  <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+  <span class="sr-only">Note:</span>
+  No handles found!
+</div>

--- a/app/views/handles/_search_form.html.erb
+++ b/app/views/handles/_search_form.html.erb
@@ -1,0 +1,68 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <a data-toggle="collapse" href="#collapse1">
+      <h3 class="panel-title">
+        Search
+      </h3>
+    </a>
+  </div>
+  <div id="collapse1" class="panel-collapse collapse <%= 'in' if @expand_sort_form %>">
+    <div class="panel-body">
+      <%= search_form_for @q do |f| %>
+        <div class="row">
+          <div class="col-md-6">
+            <%= f.label :handle_cont %>
+            <%= f.search_field :handle_cont, class: "form-control" %>
+          </div>
+
+          <div class="col-md-6">
+            <%= f.label :url_cont %>
+            <%= f.search_field :url_cont, class: "form-control" %>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-md-6">
+            <%= f.label :prefix_cont %>
+            <%= f.search_field :prefix_cont, class: "form-control" %>
+          </div>
+
+          <div class="col-md-6">
+            <%= f.label :suffix_eq %>
+            <%= f.search_field :suffix_eq, class: "form-control" %>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-md-6">
+            <%= f.label :repo_cont %>
+            <%= f.search_field :repo_cont, class: "form-control"%>
+          </div>
+
+          <div class="col-md-6">
+            <%= f.label :repo_id_cont %>
+            <%= f.search_field :repo_id_cont, class: "form-control"%>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-md-6">
+            <%= f.label :notes_cont %>
+            <%= f.search_field :notes_cont, class: "form-control" %>
+          </div>
+
+          <div class="col-md-6">
+            <%= f.label :description_cont %>
+            <%= f.search_field :description_cont, class: "form-control" %>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-md-12" style="margin-top: 10px">
+            <%= f.submit class: 'btn btn-default' %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/handles/index.html.erb
+++ b/app/views/handles/index.html.erb
@@ -1,43 +1,57 @@
 <div class="page-header">
-  <h1>Handles</h1>
-</div>
-
-<div class="btn-toolbar">
-  <div class="btn-group">
-    <%= paginate @handles %>
+  <div class="row">
+    <div class="col-xs-10">
+      <span class="h1">Handles</span>
+    </div>
+    <div class="col-xs-2">
+      <%= link_to 'New Handle', new_handle_path, class: 'btn btn-success pull-right' %>
+    </div>
   </div>
-  <%= link_to 'New Handle', new_handle_path, class: 'btn btn-success' %>
 </div>
 
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th><%= sort_link(@q, :handle, [:handle, :prefix, :suffix]) %></th>
-      <th><%= sort_link(@q, :url) %></th>
-      <th><%= sort_link(@q, :repo) %></th>
-      <th><%= sort_link(@q, :repo_id) %></th>
-      <td><%= sort_link(@q, :updated_at, 'Last Update') %></td>
-      <th></th>
-    </tr>
-  </thead>
+<div>
+  <%= render 'handles/search_form', q: @q %>
+</div>
 
-  <tbody>
-    <% @handles.each do |handle| %>
+<% if @show_no_handles_found %>
+  <%= render 'handles/no_handles_found' %>
+<% else %>
+  <div class="btn-toolbar">
+    <div class="btn-group">
+      <%= paginate @handles %>
+    </div>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
       <tr>
-        <td><%= link_to handle.to_handle_string, handle %></td>
-        <td><%= handle.url %></td>
-        <td><%= handle.repo %></td>
-        <td><%= handle.repo_id %></td>
-        <td title="<%= handle.updated_at.to_formatted_s %>"><%= time_ago_in_words(handle.updated_at) %> ago</td>
-        <td>
-          <span>
-          <%= link_to 'Edit', edit_handle_path(handle), class: 'btn btn-info' %>
-          <%= link_to 'Delete', handle, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %>
-          </span>
-        </td>
+        <th><%= sort_link(@q, :handle, [:handle, :prefix, :suffix]) %></th>
+        <th><%= sort_link(@q, :url) %></th>
+        <th><%= sort_link(@q, :repo) %></th>
+        <th><%= sort_link(@q, :repo_id) %></th>
+        <th><%= sort_link(@q, :updated_at, 'Last Update') %></th>
+        <th></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
 
-<%= paginate @handles %>
+    <tbody>
+      <% @handles.each do |handle| %>
+        <tr>
+          <td><%= link_to handle.to_handle_string, handle %></td>
+          <td><%= handle.url %></td>
+          <td><%= handle.repo %></td>
+          <td><%= handle.repo_id %></td>
+          <td title="<%= handle.updated_at.to_formatted_s %>"><%= time_ago_in_words(handle.updated_at) %> ago</td>
+          <td>
+            <span>
+            <%= link_to 'Edit', edit_handle_path(handle), class: 'btn btn-info' %>
+            <%= link_to 'Delete', handle, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %>
+            </span>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @handles %>
+<% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,11 +1,22 @@
 <h1>UMD Handle Service</h1>
 
-<p>
-Welcome to the UMD Handle Service.
-<p>
+<div id="home-jumbo" class='jumbotron'>
+  <div class="row">
+  <%= search_form_for @q do |f| %>
+    <div class="form-inline text-center">
+      <%= f.label :handle_cont, 'Handle' %>
+      <%= f.search_field :handle_cont, {placeholder: 'e.g. 1903.1/22', class:'form-control'} %>
+      <%= f.submit url: handles_url, class: 'btn btn-default'  %>
+    </div>
+  <% end %>
+  </div>
+</div>
 
-<p>Available services</p>
-<ul>
-  <li><%= link_to 'List of Handles', handles_path %></li>
-  <li>TODO Search handles</li>
-</ul>
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title">Other Services</h3>
+  </div>
+  <div class="panel-body">
+    <%= link_to 'Handles List', handles_path, class: "btn btn-default" %>
+  </div>
+</div>

--- a/test/controllers/handles_controller_test.rb
+++ b/test/controllers/handles_controller_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class HandlesControllerTest < ActionController::TestCase
+  test 'index -  search panel not expanded when there are no query params' do
+    get :index
+    assert_equal false, assigns(:expand_sort_form)
+  end
+
+  test 'index - search panel expanded when search query params exist' do
+    get :index, params: { q: { repo_cont: 'fcrepo' } }
+    assert_equal true, assigns(:expand_sort_form)
+  end
+
+  test 'index -  search panel not expanded when there is only a sort query parameter' do
+    get :index, params: { q: { s: 'url asc' } }
+    assert_equal false, assigns(:expand_sort_form)
+  end
+
+  test 'index - show no handles message when no handles displayed' do
+    get :index, params: { q: { repo_cont: 'NON-EXISTENT_REPO' } }
+
+    # The search should return no results
+    handles = assigns(:handles)
+    assert handles.count.zero?
+
+    assert assigns(:show_no_handles_found)
+  end
+
+  test 'index - show no handles message now shown when handles displayed' do
+    get :index
+
+    # The search should have at least one result
+    handles = assigns(:handles)
+    assert_not handles.count.zero?
+
+    assert_not assigns(:show_no_handles_found)
+  end
+end

--- a/test/integration/handles_integration_test.rb
+++ b/test/integration/handles_integration_test.rb
@@ -2,7 +2,8 @@
 
 require 'test_helper'
 
-class HandlesControllerTest < ActionDispatch::IntegrationTest
+# Integration tests for Handles controller
+class HandlesIntegrationTest < ActionDispatch::IntegrationTest
   setup do
     @handle = handles(:one)
   end

--- a/test/system/handles_test.rb
+++ b/test/system/handles_test.rb
@@ -10,7 +10,7 @@ class HandlesTest < ApplicationSystemTestCase
 
   test 'visiting the index' do
     visit handles_url
-    assert_selector 'h1', text: 'Handles'
+    assert_selector '.h1', text: 'Handles'
   end
 
   test 'creating a Handle' do


### PR DESCRIPTION
Added ability to search for a specific handle on the application home
page.

Added search form to the "Handles" index page.

Added "handle" Ransack object to the Handle model, so that a combined
"prefix/suffix" making up a handle could be searched.

Added "rails-controller-testing" gem to enable controller-specific behavior to be more easily tested.

https://issues.umd.edu/browse/LIBITD-1884