### PR TITLE
LIBITD-1886. Removed parallel test execution

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,8 @@ Minitest::Reporters.use!(
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
-  parallelize(workers: :number_of_processors)
+  # Commented out due to https://github.com/simplecov-ruby/simplecov/issues/718
+  # parallelize(workers: :number_of_processors)
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all


### PR DESCRIPTION
Disabled parallel test execution because it is causing the "simplecov"
code coverage tool to report unhelpful results.

https://issues.umd.edu/browse/LIBITD-1886