### PR TITLE
LIBITD-1901. Added API POST endpoint for minting new handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@ Edit the '.env" file:
 
 and set the parameters:
 
-| Parameter           | Value                                |
-| ------------------- | ------------------------------------ |
-| HOST                | handle-host                          |
-| JWT_SECRET          | (Output from the uuidgen command)    |
-| SAML_SP_PRIVATE_KEY | (Output from first kubectl command)  |
-| SAML_SP_CERTIFICATE | (Output from second kubectl command) |
+| Parameter              | Value                                |
+| ---------------------- | ------------------------------------ |
+| HANDLE_HTTP_PROXY_BASE | (For local development, an arbitrary URL such as "http://hdl-local.lib.umd.edu/") |
+| HOST                   | handle-local                         |
+| JWT_SECRET             | (Output from the uuidgen command)    |
+| SAML_SP_PRIVATE_KEY    | (Output from first kubectl command)  |
+| SAML_SP_CERTIFICATE    | (Output from second kubectl command) |
 
 4) Migrate the database and run the application:
 

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -3,6 +3,9 @@
 module Api
   # Base class for REST API Controllers
   class ApiController < ActionController::Base # rubocop:disable Rails/ApplicationController
+    # Disable CSRF for API requests (see https://stackoverflow.com/a/34252150)
+    protect_from_forgery with: :null_session
+
     before_action :authenticate_request!
 
     def authenticate_request!(_opts = {})
@@ -19,11 +22,11 @@ module Api
     def get_jwt_token(request)
       # Retrieve JWT token from header
       auth_header = request.authorization
-      raise ArgumentError('Authorization header not provided in request') unless auth_header
+      raise ArgumentError, 'Authorization header not provided in request' unless auth_header
 
       pattern = /^Bearer /
       unless auth_header.match(pattern)
-        raise ArgumentError("Authorization header format not recognized: #{auth_header}")
+        raise ArgumentError, "Authorization header format not recognized: #{auth_header}"
       end
 
       auth_header.gsub(pattern, '')
@@ -36,6 +39,7 @@ module Api
       jwt_secret = Rails.application.config.jwt_secret
 
       decoded_token = JWT.decode(jwt_token, jwt_secret, true, { algorithm: 'HS256' })
+
       if decoded_token && decoded_token[0]
         payload = decoded_token[0]
         role = payload['role']

--- a/app/controllers/api/v1/handles_controller.rb
+++ b/app/controllers/api/v1/handles_controller.rb
@@ -12,8 +12,17 @@ module Api
       end
 
       def create
-        respond_with Handle.create(params[:handle])
+        @handle = Handle.new(handle_params)
+
+        render json: { errors: @handle.errors.full_messages }, status: :bad_request unless @handle.save
       end
+
+      private
+
+        # Only allow a list of trusted parameters through.
+        def handle_params
+          params.require(:handle).permit(:prefix, :url, :repo, :repo_id, :description, :notes)
+        end
     end
   end
 end

--- a/app/views/api/v1/handles/create.json.jbuilder
+++ b/app/views/api/v1/handles/create.json.jbuilder
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+json.set! :suffix, @handle.suffix.to_s # Force suffix to be a string
+json.extract! @handle, :handle_url
+json.request do
+  json.call(@handle, :prefix, :repo, :repo_id, :url)
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,11 @@ module UmdHandle
     #     uuidgen | shasum -a256 | cut -d' ' -f1
     config.jwt_secret=ENV['JWT_SECRET']
 
+    # The base URL (including a trailing slash) for the handle proxy server
+    # associated with this application.
+    # For example: "https://hdl-test.lib.umd.edu/"
+    config.handle_http_proxy_base=ENV['HANDLE_HTTP_PROXY_BASE']
+
     # Configure the hostname, when HOST is provided.
     # Note: A HOST environment variable (typically provided by a ".env" file)
     # is REQUIRED when running the application on a server.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       constraints(prefix: /[^\/]+/) do # Allow prefixes to contain "."
         get 'handles/:prefix/:suffix' => 'handles#show', as: :handle
+        post 'handles' => 'handles#create', as: :new_handle
       end
     end
   end

--- a/docs/umd-handle-open-api-v1.yml
+++ b/docs/umd-handle-open-api-v1.yml
@@ -3,7 +3,7 @@ info:
   version: 1.0.0
   title: umd-handle API
   description: The umd-handle service API
-  
+
 servers:
   - url: https://handle.lib.umd.edu/api/v1
 
@@ -18,7 +18,7 @@ components:
     UnauthorizedError:
       description: Access token is missing or invalid
 security:
-  - bearerAuth: [] 
+  - bearerAuth: []
 
 tags:
 - name: "handles"
@@ -72,27 +72,37 @@ paths:
         content:
           application/json:
             schema:
-              type: object 
+              type: object
               required:
+                - prefix
                 - url
                 - repo
                 - repo_id
               properties:
+                prefix:
+                  description: The Handle.net prefix to use for the resource
+                  type: string
+                  example: '1903.1'
                 url:
                   description: The URL the handle should resolve to
                   type: string
+                  example: 'http://example.com/resource/abc/123'
                 repo:
                   description: The source repository for the resource
                   type: string
+                  example: 'aspace'
                 repo_id:
                   description: The internal id of the resource in the source repository
                   type: string
+                  example: 'abc:123'
                 description:
                   description: A short human-readable description of the resource, typically the title of the resource
                   type: string
+                  example: 'An example resource'
                 notes:
                   description: Any additional notes about the resource
                   type: string
+                  example: 'An example resource used in demonstrating the REST API.'
       responses:
         '200':
           description: 'Successful creation of a handle'
@@ -101,14 +111,30 @@ paths:
               schema:
                 type: object
                 required:
-                  - prefix
+                  - request
                   - suffix
-                  - proxy_url
+                  - handle_url
                 properties:
-                  prefix:
-                    description: The handle prefix
-                    example: '1903.1'
-                    type: string
+                  request:
+                    type: object
+                    description: The parameters provided in the request
+                    properties:
+                      prefix:
+                        description: The prefix provided in the request.
+                        type: string
+                        example: '1903.1'
+                      repo:
+                        description: The repo provided in the request.
+                        type: string
+                        example: 'aspace'
+                      repo_id:
+                        description: The repo_id provided in the request.
+                        type: string
+                        example: 'abc:123'
+                      url:
+                        description: The resource URL provided in the request.
+                        type: string
+                        example: 'http://example.com/resource/abc/123'
                   suffix:
                     description: The handle suffix
                     example: '1'
@@ -119,6 +145,19 @@ paths:
                     type: string
         '400':
           description: 'Unsuccessful request due to invalid parameters, such as missing parameters, or unknown repository.'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    description: A list of error messages
+                    example: ["Prefix 'NON-EXISTENT PREFIX' is not a valid prefix"]
+                    type: array
+                    items:
+                      type: string
+
+
         '401':
           $ref: '#/components/responses/UnauthorizedError'
-        
+

--- a/env_example
+++ b/env_example
@@ -19,6 +19,10 @@ SECRET_KEY_BASE=
 # uuidgen | shasum -a256 | cut -d' ' -f1
 JWT_SECRET=
 
+# The base URL (including a trailing slash) for the handle proxy server
+# associated with this application. For example: "https://hdl-test.lib.umd.edu/"
+HANDLE_HTTP_PROXY_BASE=
+
 # --- config/database.yml
 # The type of database
 PROD_DATABASE_ADAPTER=postgresql

--- a/test/controllers/api/api_authentication_test.rb
+++ b/test/controllers/api/api_authentication_test.rb
@@ -33,6 +33,15 @@ module Api
       assert_equal 401, response.status
     end
 
+    test 'JWT tokens with empty payload are rejected' do
+      payload = {}
+      jwt_token = JWT.encode(payload, @jwt_secret, 'HS256')
+      request.headers['Authorization'] = "Bearer #{jwt_token}"
+
+      get :show, params: @path_params, format: :json
+      assert_equal 401, response.status
+    end
+
     test 'requests without expected JWT payload in the Authorization header are rejected' do
       payload = { foo: 'bar' }
       jwt_token = JWT.encode(payload, @jwt_secret, 'HS256')

--- a/test/controllers/api/v1/handles_controller_test.rb
+++ b/test/controllers/api/v1/handles_controller_test.rb
@@ -9,6 +9,8 @@ module Api
       include Devise::Test::ControllerHelpers
       def setup
         use_jwt_token
+        Rails.application.config.handle_http_proxy_base = 'http://test.example.com/'
+        request.headers['CONTENT_TYPE'] = 'application/json'
       end
 
       test 'show returns 404 when handle is not found' do
@@ -16,7 +18,7 @@ module Api
 
         get :show, params: @path_params, format: :json
 
-        assert_equal 404, response.status
+        assert_response :not_found
       end
 
       test 'show returns resolved URL when handle is found' do
@@ -27,6 +29,79 @@ module Api
 
         parsed_response = JSON.parse response.body
         assert_equal one.url, parsed_response['url']
+      end
+
+      test 'create return HTTP status 400 when provided unknown prefix' do
+        body_json = create_request_body(prefix: 'NON-EXISTENT PREFIX').to_json
+
+        post :create, body: body_json, format: :json
+
+        assert_response :bad_request
+        parsed_response = JSON.parse response.body
+        assert_includes(parsed_response['errors'], "Prefix 'NON-EXISTENT PREFIX' is not a valid prefix")
+      end
+
+      test 'create return HTTP status 400 when provided unknown repo' do
+        body_json = create_request_body(repo: 'NON-EXISTENT REPO').to_json
+
+        post :create, body: body_json, format: :json
+
+        assert_response :bad_request
+        parsed_response = JSON.parse response.body
+        assert_includes(parsed_response['errors'], "Repository 'NON-EXISTENT REPO' is not a valid repository")
+      end
+
+      test 'create return HTTP status 400 when a required field is missing' do
+        required_fields = %i[prefix url repo repo_id]
+
+        required_fields.each do |required_field|
+          # Remove required field from body hash
+          body_json = create_request_body.except(required_field).to_json
+
+          post :create, body: body_json, format: :json
+
+          assert_response :bad_request
+          parsed_response = JSON.parse response.body
+          expected_error = "#{Handle.human_attribute_name(required_field)} is required"
+          assert_includes(parsed_response['errors'], expected_error)
+        end
+      end
+
+      test 'create returns new handle when provided correct parameters' do
+        expected_prefix = Handle.prefixes.first
+        expected_suffix = Handle.group(:prefix).maximum(:suffix)[expected_prefix] + 1
+        expected_handle_url = "#{Rails.application.config.handle_http_proxy_base}#{expected_prefix}/#{expected_suffix}"
+
+        body_json = create_request_body(prefix: expected_prefix).to_json
+
+        post :create, body: body_json, format: :json
+
+        assert_response :success
+        parsed_response = JSON.parse response.body
+        expected_response = {
+          suffix: expected_suffix.to_s, handle_url: expected_handle_url,
+          request: {
+            prefix: expected_prefix,
+            repo: Handle.repos.first,
+            repo_id: 'abc123',
+            url: 'http://example.com/handles_controller_test'
+          }.stringify_keys
+        }.stringify_keys
+        assert_equal(expected_response, parsed_response)
+        # assert_equal(expected_prefix, parsed_response['prefix'])
+        # assert_equal(expected_suffix, parsed_response['suffix'])
+        # assert_equal(expected_handle_url, parsed_response['handle_url'])
+      end
+
+      def create_request_body(prefix: Handle.prefixes.first, repo: Handle.repos.first)
+        {
+          prefix: prefix,
+          url: 'http://example.com/handles_controller_test',
+          repo: repo,
+          repo_id: 'abc123',
+          description: 'A test URL',
+          notes: 'Notes for a test URL'
+        }
       end
     end
   end


### PR DESCRIPTION
Added a POST endpoint to the API to support minting new handles.

Updated the "docs/umd-handle-open-api-v1.yml" OpenAPI 3.0 spec with
additional information.

Added HANDLE_HTTP_PROXY_BASE to env_example to enable configuring the
base URL to use when reporting handle URLs.

https://issues.umd.edu/browse/LIBITD-1901