### PR TITLE
LIBITD-1904. Disable turbolinks for new handle link.

### DIFF
--- a/app/views/handles/index.html.erb
+++ b/app/views/handles/index.html.erb
@@ -4,7 +4,7 @@
       <span class="h1">Handles</span>
     </div>
     <div class="col-xs-2">
-      <%= link_to 'New Handle', new_handle_path, class: 'btn btn-success pull-right' %>
+      <%= link_to 'New Handle', new_handle_path, class: 'btn btn-success pull-right', data: { turbolinks: false } %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The CSRF Token verfication fails when the form is retrieved via XHR request.

https://issues.umd.edu/browse/LIBITD-1904