### PR TITLE
LIBITD-1904. Fix for CSRF token issue when using Turbolinks with forms

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -12,3 +12,7 @@ import 'bootstrap/dist/js/bootstrap';
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()
+
+// The following is needed to reset the authenticity token on forms
+// when using TurboLinks. See https://stackoverflow.com/a/64257384
+$(document).on('turbolinks:load', function(){ $.rails.refreshCSRFTokens(); });

--- a/app/views/layouts/_umd_lib.html.erb
+++ b/app/views/layouts/_umd_lib.html.erb
@@ -2,10 +2,10 @@
 <html>
 <head>
   <title><%= yield(:app_name) %></title>
-  <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
+  <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   <%= yield :additional_head_content %>
 </head>
 <body role="document">


### PR DESCRIPTION
Fixed a CSRF token verification failure when submitting a form that
had been added to the page by Turbolinks, as suggested in

https://stackoverflow.com/a/64257384

It is not 100% clear why this change is necessary, as it seems
like something that Rails should already be doing, but it works for now.

Also switched the order of stylesheet_link_tag/javascript_pack_tag and
csrf_meta_tags/csp_meta_tag includes in "_umd_lib.html.erb" to better
match layout in a default Rails 6 application.

https://issues.umd.edu/browse/LIBITD-1904