### PR TITLE
LIBITD-1906. Updated "config.host" to include K8S_INTERNAL_HOST

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,6 +42,7 @@ module UmdHandle
     if ENV['HOST'].present? && !Rails.env.test?
       config.hosts << /\A10\.\d+\.\d+\.\d+\z/
       config.hosts << ENV['HOST']
+      config.hosts << ENV['K8S_INTERNAL_HOST'] if ENV['K8S_INTERNAL_HOST']
       config.action_mailer.default_url_options = { host: ENV['HOST'] }
     end
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -281,7 +281,7 @@ Devise.setup do |config|
   end
 
   if ENV['HOST'].present?
-    saml_host = (ENV['HOST'].include? "local") ? "#{ENV['HOST']}:3000" : ENV['HOST']
+    saml_host = (ENV['HOST'].include? "local") ? "#{ENV['HOST']}:#{ENV.fetch("PORT") { 3000 }}" : ENV['HOST']
     saml_scheme = (ENV['HOST'].include? "local") ? "http" : "https"
     Rails.logger.info("Configuring SAML authentication: saml_scheme=#{saml_scheme}, saml_host=#{saml_host}")
 

--- a/env_example
+++ b/env_example
@@ -53,6 +53,11 @@ PROD_DATABASE_POOL=10
 # Hostname of the application
 HOST=handle-local
 
+# --- config/application.rb
+# When running in Kubernetes, the internal Kubernetes host name for the pod
+# to allow cross-stack HTTP communication.
+K8S_INTERNAL_HOST=umd-handle-app
+
 # --- config/initializers/devise.rb
 
 # SAML SP's Signing Key


### PR DESCRIPTION
Rails 6 has a new feature to prevent "DNS Rebinding" attacks, described
in https://github.com/rails/rails/pull/33145, by allowing specific
hostnames to be added to an allowed list, "config.host" in the
"config/application.rb" file. If the hostname of the request does not
match a name in "config.host" the request is rejected.

By default, the "config.host" allow list is not set, and allows
connections for any host.

As part of the LIBITD-1870, the "config.host" allow list was added to
use the "HOST" environment variable. Added a "K8s_INTERNAL_HOST"
environment variable, which is added to the "config.host" in the
"config/application.rb" file, if present. This enables the
Kubernetes internal host name to be set in the k8s-umd-handle
configuration.

In the "env_example" file, provided a default value of "umd-handle-app"
for the "K8S_INTERNAL_HOST", as that seems likely to be correct
(and does not matter in the local development environment).

Also updated Devise config to respect PORT environment variable, if provided.

https://issues.umd.edu/browse/LIBITD-1906