### PR TITLE
LIBITD-1917. Added "exists" endpoint for checking whether handle exists

### DIFF
--- a/app/controllers/api/v1/handles_controller.rb
+++ b/app/controllers/api/v1/handles_controller.rb
@@ -30,6 +30,19 @@ module Api
         @exists = !@handle.nil?
       end
 
+      def info
+        @prefix = params[:prefix]
+        @suffix = params[:suffix]
+
+        @errors = []
+        @errors << '"prefix" is required' if @prefix.blank?
+        @errors << '"suffix" is required' if @suffix.blank?
+        render json: { errors: @errors }, status: :bad_request and return unless @errors.empty?
+
+        @handle = Handle.find_by prefix: @prefix, suffix: @suffix
+        @exists = !@handle.nil?
+      end
+
       private
 
         # Only allow a list of trusted parameters through.

--- a/app/controllers/api/v1/handles_controller.rb
+++ b/app/controllers/api/v1/handles_controller.rb
@@ -17,6 +17,19 @@ module Api
         render json: { errors: @handle.errors.full_messages }, status: :bad_request unless @handle.save
       end
 
+      def exists
+        @repo = params[:repo]
+        @repo_id = params[:repo_id]
+
+        @errors = []
+        @errors << '"repo" is required' if @repo.blank?
+        @errors << '"repo_id" is required' if @repo_id.blank?
+        render json: { errors: @errors },  status: :bad_request and return unless @errors.empty?
+
+        @handle = Handle.find_by repo: @repo, repo_id: @repo_id
+        @exists = !@handle.nil?
+      end
+
       private
 
         # Only allow a list of trusted parameters through.

--- a/app/views/api/v1/handles/exists.json.jbuilder
+++ b/app/views/api/v1/handles/exists.json.jbuilder
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Force suffix to be returned as a string, instead of an integer, in case we
+# ever want to return alphanumeric suffixes
+suffix = @handle&.suffix.to_s
+
+json.set! :exists, @exists
+json.extract! @handle, :handle_url unless @handle.nil?
+json.extract! @handle, :prefix unless @handle.nil?
+json.set! :suffix, suffix if suffix.present?
+json.extract! @handle, :url unless @handle.nil?
+json.request do
+  json.set! :repo, @repo
+  json.set! :repo_id, @repo_id
+end

--- a/app/views/api/v1/handles/info.json.jbuilder
+++ b/app/views/api/v1/handles/info.json.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+json.set! :exists, @exists
+json.extract! @handle, :handle_url unless @handle.nil?
+json.extract! @handle, :repo unless @handle.nil?
+json.extract! @handle, :repo_id unless @handle.nil?
+json.extract! @handle, :url unless @handle.nil?
+json.request do
+  json.set! :prefix, @prefix
+  json.set! :suffix, @suffix
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       constraints(prefix: /[^\/]+/) do # Allow prefixes to contain "."
         get 'handles/:prefix/:suffix' => 'handles#show', as: :handle
         post 'handles' => 'handles#create', as: :new_handle
+        get 'handles/exists' => 'handles#exists', as: :handle_exists
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
         get 'handles/:prefix/:suffix' => 'handles#show', as: :handle
         post 'handles' => 'handles#create', as: :new_handle
         get 'handles/exists' => 'handles#exists', as: :handle_exists
+        get 'handles/info' => 'handles#info', as: :handle_info
       end
     end
   end

--- a/docs/adr/0005-exists-and-info-api-endpoints.md
+++ b/docs/adr/0005-exists-and-info-api-endpoints.md
@@ -1,0 +1,77 @@
+# 0005 - "exists" and "info" API endpoints
+
+Date: May 11, 2021
+
+## Context
+
+The application needs to support the handle operations needed by Fedora 2.
+
+The existing Fedora 2 functionality requires the ability to determine if a
+handle currently exists, using the following combination of parameters:
+
+* "repo" and "repo_id"
+* "prefix" and "suffix"
+
+If a handle exists, the following information needs to be provided to
+Fedora 2:
+
+* repo
+* repo_id
+* prefix
+* suffix
+* handle_url
+* url
+
+The "repo"/"repo_id" lookup is definitely used by Fedora 2 when minting
+handles. It is unclear whether the "prefix"/"suffix" lookup is actually used,
+but is present in the "umfedora/handle" webapp code.
+
+## Decision
+
+It was decided to implement the functionality needed by Fedora 2 using two
+different API endpoints -- "exists" and "info".
+
+The main reasons for this are simplicity and practicality.
+
+In the initial implementation of the Fedora 2 functionality, the need for
+both a "repo"/"repo_id" and "prefix"/"suffix" lookup was not realized, so
+the "exists" endpoint (which was clearly needed by Fedora 2 to perform
+handle minting) was implemented first, and set up to use the "repo"/"repo_id"
+pair as inputs.
+
+When it was later determined that a "prefix"/"suffix" lookup would also be
+required, there were several options:
+
+1) Extend the "exists" endpoint to take a "prefix"/"suffix" input pair,
+as well as a "repo"/"repo_id" input pair.
+
+2) Create a separate "info" endpoint to take a "prefix"/"suffix" input pair,
+leaving the "exists" endpoint unchanged.
+
+3) Not provide "prefix"/"suffix" lookup functionality.
+
+While it is not clear that "prefix"/"suffix" lookup functionality is actually
+used, it could not be definitively ruled out, so simply not providing the
+functionality did not seem reasonable.
+
+Extending the "exists" endpoint is reasonably straightforward, but would
+complicate the validation logic needed to determine if all the proper
+input parameters had been provided. More importantly, there was no clear
+way to provide information about the input parameter interdependencies
+(i.e., that either a "repo"/"repo_id" pair or a "prefix"/"suffix" pair
+was required) in the OpenAPI specification of the REST API.
+
+Therefore, it was decided that the simplest and most pragmatic course was to
+add an additional "info" endpoint that would provide the necessary information.
+
+## Consequences
+
+The "exists" and "info" endpoints are very similar, mainly differing in the
+input parameters that they take. This seems less than ideal, and may become
+a mainteance issue at some point.
+
+On the other hand, these endpoints were implemented soley to support Fedora 2,
+which is not under active development, and which we hope to eventually migrate
+away from. Therefore it is unlikely that the endpoints would ever need to
+change significantly, and investing in a more perfect solution does not seem
+to be worthwhile.

--- a/docs/umd-handle-open-api-v1.yml
+++ b/docs/umd-handle-open-api-v1.yml
@@ -104,7 +104,7 @@ paths:
                         type: string
                         example: 'abc:123'
                   exists:
-                    description: Flag indicating wheter a handle exists
+                    description: Flag indicating whether a handle exists
                     example: true
                     type: boolean
                   handle_url:
@@ -133,6 +133,91 @@ paths:
                   errors:
                     description: A list of error messages
                     example: ["'repo_id' parameter is required"]
+                    type: array
+                    items:
+                      type: string
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+  /handles/info:
+    get:
+      tags:
+      - "handles"
+      description: Returns additional information about a handle
+      operationId: "info"
+      parameters:
+        - name: prefix
+          in: query
+          required: true
+          description: The handle prefix
+          schema:
+            type: string
+        - name: suffix
+          in: query
+          required: true
+          description: The handle suffix
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - request
+                  - exists
+                properties:
+                  request:
+                    type: object
+                    description: The parameters provided in the request
+                    properties:
+                      prefix:
+                        description: The prefix provided in the request.
+                        type: string
+                        example: '1903.1'
+                      suffix:
+                        description: The suffix provided in the request.
+                        type: string
+                        example: '1'
+                  exists:
+                    description: Flag indicating whether a handle exists
+                    example: true
+                    type: boolean
+                  handle_url:
+                    description: The URL for the handle, if one exists
+                    example: 'https://hdl.handle.net/1903.1/1'
+                    type: string
+                  prefix:
+                    description: The handle prefix, if one exists
+                    type: string
+                    example: '1903.1'
+                  suffix:
+                    description: The handle suffix, if one exists
+                    type: string
+                    example: '1'
+                  url:
+                    description: The URL of the resource, if one exists
+                    type: string
+                    example: 'http://example.com/resource/abc/123'
+                  repo:
+                    description: The source repository for the resource, if one exists
+                    type: string
+                    example: 'fedora2'
+                  repo_id:
+                    description: The internal id of the resource in the source repository, if one exists
+                    type: string
+                    example: 'abc:123'
+        '400':
+          description: 'Unsuccessful request due to invalid parameters, such as missing parameters, or unknown repository.'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    description: A list of error messages
+                    example: ["'prefix' parameter is required"]
                     type: array
                     items:
                       type: string

--- a/docs/umd-handle-open-api-v1.yml
+++ b/docs/umd-handle-open-api-v1.yml
@@ -61,6 +61,83 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '404':
           description: Handle not found
+  /handles/exists:
+    get:
+      tags:
+      - "handles"
+      description: Returns whether a handle exists for the given parameters
+      operationId: "exists"
+      parameters:
+        - name: repo
+          in: query
+          required: true
+          description: The repository of the resource
+          schema:
+            type: string
+        - name: repo_id
+          in: query
+          required: true
+          description: The identifier for the resource in the respository
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - request
+                  - exists
+                properties:
+                  request:
+                    type: object
+                    description: The parameters provided in the request
+                    properties:
+                      repo:
+                        description: The repo provided in the request.
+                        type: string
+                        example: 'aspace'
+                      repo_id:
+                        description: The repo_id provided in the request.
+                        type: string
+                        example: 'abc:123'
+                  exists:
+                    description: Flag indicating wheter a handle exists
+                    example: true
+                    type: boolean
+                  handle_url:
+                    description: The URL for the handle, if one exists
+                    example: 'https://hdl.handle.net/1903.1/1'
+                    type: string
+                  prefix:
+                    description: The handle prefix, if one exists
+                    type: string
+                    example: '1903.1'
+                  suffix:
+                    description: The handle suffix, if one exists
+                    type: string
+                    example: '1'
+                  url:
+                    description: The URL of the resource, if one exists
+                    type: string
+                    example: 'http://example.com/resource/abc/123'
+        '400':
+          description: 'Unsuccessful request due to invalid parameters, such as missing parameters, or unknown repository.'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    description: A list of error messages
+                    example: ["'repo_id' parameter is required"]
+                    type: array
+                    items:
+                      type: string
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
   /handles:
     post:
       tags:

--- a/test/controllers/api/api_authentication_test.rb
+++ b/test/controllers/api/api_authentication_test.rb
@@ -16,21 +16,21 @@ module Api
 
     test 'requests without Authorization header are rejected' do
       get :show, params: @path_params, format: :json
-      assert_equal 401, response.status
+      assert_response :unauthorized
     end
 
     test 'requests without "Bearer" in the Authorization header are rejected' do
       request.headers['Authorization'] = 'NOT_VALID'
 
       get :show, params: @path_params, format: :json
-      assert_equal 401, response.status
+      assert_response :unauthorized
     end
 
     test 'requests without valid JWT in the Authorization header are rejected' do
       request.headers['Authorization'] = 'Bearer NOT.VALID.JWT'
 
       get :show, params: @path_params, format: :json
-      assert_equal 401, response.status
+      assert_response :unauthorized
     end
 
     test 'JWT tokens with empty payload are rejected' do
@@ -39,7 +39,7 @@ module Api
       request.headers['Authorization'] = "Bearer #{jwt_token}"
 
       get :show, params: @path_params, format: :json
-      assert_equal 401, response.status
+      assert_response :unauthorized
     end
 
     test 'requests without expected JWT payload in the Authorization header are rejected' do
@@ -48,7 +48,7 @@ module Api
       request.headers['Authorization'] = "Bearer #{jwt_token}"
 
       get :show, params: @path_params, format: :json
-      assert_equal 401, response.status
+      assert_response :unauthorized
     end
 
     test 'requests with expected JWT payload in the Authorization header are accepted' do
@@ -57,7 +57,7 @@ module Api
       request.headers['Authorization'] = "Bearer #{jwt_token}"
 
       get :show, params: @path_params, format: :json
-      assert_equal 200, response.status
+      assert_response :success
     end
   end
 end

--- a/test/controllers/api/v1/handles_controller_exists_test.rb
+++ b/test/controllers/api/v1/handles_controller_exists_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Api
+  module V1
+    # Controller tests for the "exists" Handles REST endpoint
+    class HandlesControllerExistsTest < ActionController::TestCase
+      include Devise::Test::ControllerHelpers
+      def setup
+        use_jwt_token
+        @controller = Api::V1::HandlesController.new
+        Rails.application.config.handle_http_proxy_base = 'http://test.example.com/'
+        @request.headers['ACCEPT'] = 'application/json'
+      end
+
+      test 'exists returns 401 (Unauthorized) when authentication token not provided' do
+        @request.headers['Authorization'] = ''
+        get :exists, params: { repo: handles(:one).repo, repo_id: handles(:one).repo_id }
+        assert_response :unauthorized
+      end
+
+      test 'exists returns 400 (Bad Request) when there are no parameters' do
+        # No parameters
+        get :exists
+
+        assert_response :bad_request
+        parsed_response = JSON.parse(@response.body)
+        errors = parsed_response['errors']
+        assert_equal 2, errors.count
+        assert errors.include?('"repo" is required')
+        assert errors.include?('"repo_id" is required')
+      end
+
+      test 'exists returns 400 (Bad Request) when "repo" parameter not provided' do
+        get :exists, params: { repo_id: 'umd:327543' }
+
+        assert_response :bad_request
+        parsed_response = JSON.parse(@response.body)
+        errors = parsed_response['errors']
+        assert_equal 1, errors.count
+        assert errors.include?('"repo" is required')
+      end
+
+      test 'exists returns 400 (Bad Request) when "repo_id" parameter not provided' do
+        get :exists, params: { repo: 'fedora2' }
+
+        assert_response :bad_request
+        parsed_response = JSON.parse(@response.body)
+        errors = parsed_response['errors']
+        assert_equal 1, errors.count
+        assert errors.include?('"repo_id" is required')
+      end
+
+      test 'exists returns false when associated handle does not exist' do
+        repo = 'nonexistent_repo'
+        repo_id = 'nonexistent_repo_id'
+        get :exists, params: { repo: repo, repo_id: repo_id }
+
+        assert_response :success
+        parsed_response = JSON.parse(@response.body)
+        assert_equal false, parsed_response['exists']
+        assert_equal repo, parsed_response['request']['repo']
+        assert_equal repo_id, parsed_response['request']['repo_id']
+
+        # Following keys should not be present, as they are empty
+        assert_not parsed_response.key?('prefix')
+        assert_not parsed_response.key?('suffix')
+        assert_not parsed_response.key?('url')
+        assert_not parsed_response.key?('handle_url')
+      end
+
+      test 'exists returns true when associated handle does exist' do
+        repo = 'aspace'
+        repo_id = 'aspace_pid::1'
+        get :exists, params: { repo: repo, repo_id: repo_id }
+
+        assert_response :success
+        parsed_response = JSON.parse(@response.body)
+        assert_equal true, parsed_response['exists']
+        assert_equal 'http://test.example.com/1903.1/1', parsed_response['handle_url']
+        assert_equal '1903.1', parsed_response['prefix']
+        assert_equal '1', parsed_response['suffix']
+        assert_equal 'http://example.com/test/one', parsed_response['url']
+        assert_equal repo, parsed_response['request']['repo']
+        assert_equal repo_id, parsed_response['request']['repo_id']
+      end
+    end
+  end
+end

--- a/test/controllers/api/v1/handles_controller_info_test.rb
+++ b/test/controllers/api/v1/handles_controller_info_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Api
+  module V1
+    # Controller tests for the "info" Handles REST endpoint
+    class HandlesControllerInfoTest < ActionController::TestCase
+      include Devise::Test::ControllerHelpers
+      def setup
+        use_jwt_token
+        @controller = Api::V1::HandlesController.new
+        Rails.application.config.handle_http_proxy_base = 'http://test.example.com/'
+        @request.headers['ACCEPT'] = 'application/json'
+      end
+
+      test 'info returns 401 (Unauthorized) when authentication token not provided' do
+        @request.headers['Authorization'] = ''
+        get :info, params: { prefix: handles(:one).prefix, repo_id: handles(:one).suffix }
+        assert_response :unauthorized
+      end
+
+      test 'info returns 400 (Bad Request) when there are no parameters' do
+        # No parameters
+        get :info
+
+        assert_response :bad_request
+        parsed_response = JSON.parse(@response.body)
+        errors = parsed_response['errors']
+        assert_equal 2, errors.count
+        assert errors.include?('"prefix" is required')
+        assert errors.include?('"suffix" is required')
+      end
+
+      test 'info returns 400 (Bad Request) when "prefix" parameter not provided' do
+        get :info, params: { suffix: '1' }
+
+        assert_response :bad_request
+        parsed_response = JSON.parse(@response.body)
+        errors = parsed_response['errors']
+        assert_equal 1, errors.count
+        assert errors.include?('"prefix" is required')
+      end
+
+      test 'info returns 400 (Bad Request) when "suffix" parameter not provided' do
+        get :info, params: { prefix: '1903.1' }
+
+        assert_response :bad_request
+        parsed_response = JSON.parse(@response.body)
+        errors = parsed_response['errors']
+        assert_equal 1, errors.count
+        assert errors.include?('"suffix" is required')
+      end
+
+      test 'info returns false when associated handle does not exist' do
+        prefix = 'nonexistent_prefix'
+        suffix = 'nonexistent_suffix'
+        get :info, params: { prefix: prefix, suffix: suffix }
+
+        assert_response :success
+        parsed_response = JSON.parse(@response.body)
+        assert_equal false, parsed_response['exists']
+        assert_equal prefix, parsed_response['request']['prefix']
+        assert_equal suffix, parsed_response['request']['suffix']
+
+        # Following keys should not be present, as they are empty
+        assert_not parsed_response.key?('repo')
+        assert_not parsed_response.key?('repo_id')
+        assert_not parsed_response.key?('url')
+        assert_not parsed_response.key?('handle_url')
+      end
+
+      test 'info returns true when associated handle does exist' do
+        expected_handle = handles(:one)
+        prefix = expected_handle.prefix
+        suffix = expected_handle.suffix
+        get :info, params: { prefix: prefix, suffix: suffix }
+
+        expected_handle_url = "http://test.example.com/#{prefix}/#{suffix}"
+        assert_response :success
+        parsed_response = JSON.parse(@response.body)
+        assert_equal true, parsed_response['exists']
+        assert_equal expected_handle_url, parsed_response['handle_url']
+        assert_equal expected_handle.repo, parsed_response['repo']
+        assert_equal expected_handle.repo_id, parsed_response['repo_id']
+        assert_equal expected_handle.url, parsed_response['url']
+        assert_equal prefix, parsed_response['request']['prefix']
+        assert_equal suffix.to_s, parsed_response['request']['suffix']
+      end
+    end
+  end
+end

--- a/test/controllers/api/v1/handles_controller_test.rb
+++ b/test/controllers/api/v1/handles_controller_test.rb
@@ -13,7 +13,7 @@ module Api
         request.headers['CONTENT_TYPE'] = 'application/json'
       end
 
-      test 'show returns 404 when handle is not found' do
+      test 'show returns 404 (Not Found) when handle is not found' do
         @path_params = { prefix: 'NON-EXISTENT PREFIX', suffix: '42' }
 
         get :show, params: @path_params, format: :json
@@ -31,7 +31,7 @@ module Api
         assert_equal one.url, parsed_response['url']
       end
 
-      test 'create return HTTP status 400 when provided unknown prefix' do
+      test 'create returns 400 (Bad Request) when provided unknown prefix' do
         body_json = create_request_body(prefix: 'NON-EXISTENT PREFIX').to_json
 
         post :create, body: body_json, format: :json
@@ -41,7 +41,7 @@ module Api
         assert_includes(parsed_response['errors'], "Prefix 'NON-EXISTENT PREFIX' is not a valid prefix")
       end
 
-      test 'create return HTTP status 400 when provided unknown repo' do
+      test 'create returns 400 (Bad Request) when provided unknown repo' do
         body_json = create_request_body(repo: 'NON-EXISTENT REPO').to_json
 
         post :create, body: body_json, format: :json
@@ -51,7 +51,7 @@ module Api
         assert_includes(parsed_response['errors'], "Repository 'NON-EXISTENT REPO' is not a valid repository")
       end
 
-      test 'create return HTTP status 400 when a required field is missing' do
+      test 'create returns 400 (Bad Request) when a required field is missing' do
         required_fields = %i[prefix url repo repo_id]
 
         required_fields.each do |required_field|
@@ -88,9 +88,6 @@ module Api
           }.stringify_keys
         }.stringify_keys
         assert_equal(expected_response, parsed_response)
-        # assert_equal(expected_prefix, parsed_response['prefix'])
-        # assert_equal(expected_suffix, parsed_response['suffix'])
-        # assert_equal(expected_handle_url, parsed_response['handle_url'])
       end
 
       def create_request_body(prefix: Handle.prefixes.first, repo: Handle.repos.first)

--- a/test/fixtures/handles.yml
+++ b/test/fixtures/handles.yml
@@ -5,7 +5,7 @@ one:
   suffix: 1
   url: http://example.com/test/one
   repo: aspace
-  repo_id: MyString
+  repo_id: aspace_pid::1
   description: MyString
   notes: MyText
 
@@ -14,6 +14,6 @@ two:
   suffix: 2
   url: http://example.com/test/two
   repo: avalon
-  repo_id: MyString
+  repo_id: avalon_pid::2
   description: MyString
   notes: MyText


### PR DESCRIPTION
Added a "handles/exists" endpoint that takes "repo" and "repo_id" HTTP
parameters to determine if a handle with the given values exists. HTTP
parameters are being used in case this endpoint needs to be extended in
the future to take, for example, a static URL, or other lookup field.

Updated the "docs/umd-handle-open-api-v1.yml" OpenAPI specification for
the new endpoint.

https://issues.umd.edu/browse/LIBITD-1917