### PR TITLE
LIBITD-1923. Fixed SimpleCov code coverage reporting in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,14 +144,7 @@ pipeline {
           recordIssues(tools: [ruboCop(reportEncoding: 'UTF-8')], unstableTotalAll: 1)
 
           // Collect coverage reports
-          publishHTML([
-                        allowMissing: false,
-                        alwaysLinkToLastBuild: false,
-                        keepAll: true,
-                        reportDir: 'coverage/rcov',
-                        reportFiles: 'index.html',
-                        reportName: "RCov Report"
-                      ])
+          step([$class: 'RcovPublisher', reportDir: 'coverage/rcov/'])
         }
       }
     }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::RcovFormatter
 ]
-SimpleCov.start
+SimpleCov.start 'rails'
 
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'


### PR DESCRIPTION
The "test/test_helper.rb" was modified, changing:

```
SimpleCov.start
```

to

```
SimpleCov.start 'rails'
```

This causes SimpleCov to ignore many of the Rails boilerplate Ruby
files, such as those in the "config/" directory, and produces more
accurate statistics, because those file are not included.

In the "Jenkinsfile", the code coverage report was being published using

```
          publishHTML([
                        allowMissing: false,
                        alwaysLinkToLastBuild: false,
                        keepAll: true,
                        reportDir: 'coverage/rcov',
                        reportFiles: 'index.html',
                        reportName: "RCov Report"
                      ])
```

However, this would not produce a code coverage graph, and the report
itself was not quite working properly (the "graphs" of the code coverage
for particular classes were not being displayed/colored properly).

Replacing this step with a "RubyMetrics" step:

```
step([$class: 'RcovPublisher', reportDir: 'coverage/rcov/'])
````

produced the desired graphical output and a better report.

https://issues.umd.edu/browse/LIBITD-1923